### PR TITLE
Fix missing closing brace in calendar API route

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,8 @@ function createServer() {
       res.status(400).json({ error: message });
     }
 
+  });
+
   app.get("*", (_, res) => {
     res.sendFile(path.join(publicDirectory, "index.html"));
   });


### PR DESCRIPTION
## Summary
- add the missing closing call for the `/api/calendar` route handler in `server.ts`

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914840617488328ad05715c68e28d0b)